### PR TITLE
Remove pip cache

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux \
     # Pre-install the compiled requirements to save some build time for child
     # images.
     && pip-sync base-requirements.txt \
-    # Remove build dependencies to reduce layer size. Note: Intentionally not
-    # removing the pip cache, in order to speed up the pip-compile step for
-    # child images.
-    && apk del .build-deps
+    # Remove build dependencies and pip cache to reduce layer size. Note that
+    # the pip-tools cache is kept to speed up `pip-compile` in child images.
+    && apk del .build-deps \
+    && rm -rf /root/.cache/pip

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux \
         --output-file base-requirements.txt base-requirements.in \
     # Pre-install the compiled requirements to save some build time for child
     # images.
-    && pip-sync base-requirements.txt
-    # Note: Intentionally not removing the pip cache, in order to speed up the
-    # pip-compile step for child images.
+    && pip-sync base-requirements.txt \
+    # Remove the pip cache to reduce layer size. Note that the pip-tools cache
+    # is kept to speed up `pip-compile` in child images.
+    && rm -rf /root/.cache/pip


### PR DESCRIPTION
I looked a bit more into the cache usage and found that my assumption that `pip-compile` needs the pip cache is wrong; rather `pip-tools` has its own cache. By deleting `.cache/pip` (but *not* the entire `.cache` dir), I was able to reduce image size quite a bit:

* `dddecaf/wsgi-base:alpine` from 359MB to 213MB
* `dddecaf/postgres-base` from 438MB to 270MB
* `gcr.io/dd-decaf-cfbf6/modeling-base` from 3.22GB to 1.09GB

`pip-compile` for child images, using the caches in these base images, still completes in 5-6 seconds.

Same change in https://github.com/DD-DeCaF/modeling-base/pull/4 and https://github.com/DD-DeCaF/postgres-base/pull/2.

In regards to still keeping the pip-tools cache: For comparison, the `simulations` service image currently consumes 902MB, which increases to 1.1GB when built from these new base images. Increases in non-modeling services are much smaller.