### PR TITLE
feat: add compiler image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin
 install:
 - docker build -t ${IMAGE}:alpine -t ${IMAGE}:alpine-${IMAGE_HASH_TAG} ./alpine
+- docker build -t ${IMAGE}:alpine-compiler ./alpine-compiler
 - docker build -t ${IMAGE}:debian -t ${IMAGE}:debian-${IMAGE_HASH_TAG} ./debian
 script:
 - docker run --rm ${IMAGE}:alpine gunicorn --version
@@ -23,6 +24,7 @@ script:
 after_success:
 - docker push ${IMAGE}:alpine
 - docker push ${IMAGE}:alpine-${IMAGE_HASH_TAG}
+- docker push ${IMAGE}:alpine-compiler
 - docker push ${IMAGE}:debian
 - docker push ${IMAGE}:debian-${IMAGE_HASH_TAG}
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin
 install:
 - docker build -t ${IMAGE}:alpine -t ${IMAGE}:alpine-${IMAGE_HASH_TAG} ./alpine
-- docker build -t ${IMAGE}:alpine-compiler ./alpine-compiler
+- docker build -t ${IMAGE}:alpine-compiler -t ${IMAGE}:alpine-compiler-${IMAGE_HASH_TAG} ./alpine-compiler
 - docker build -t ${IMAGE}:debian -t ${IMAGE}:debian-${IMAGE_HASH_TAG} ./debian
 script:
 - docker run --rm ${IMAGE}:alpine gunicorn --version
@@ -25,6 +25,7 @@ after_success:
 - docker push ${IMAGE}:alpine
 - docker push ${IMAGE}:alpine-${IMAGE_HASH_TAG}
 - docker push ${IMAGE}:alpine-compiler
+- docker push ${IMAGE}:alpine-compiler-${IMAGE_HASH_TAG}
 - docker push ${IMAGE}:debian
 - docker push ${IMAGE}:debian-${IMAGE_HASH_TAG}
 notifications:

--- a/alpine-compiler/Dockerfile
+++ b/alpine-compiler/Dockerfile
@@ -1,0 +1,9 @@
+FROM dddecaf/wsgi-base:alpine
+
+RUN set -eux \
+    # Install build tools. These can be required for the `pip-compile` step in
+    # child images that require to build packages from source.
+    && apk add g++ \
+    # Re-run pip-compile in order to pre-populate the pip cache.
+    && pip-compile --generate-hashes --output-file /dev/null \
+      /opt/base-requirements.txt

--- a/alpine-compiler/Dockerfile
+++ b/alpine-compiler/Dockerfile
@@ -3,7 +3,7 @@ FROM dddecaf/wsgi-base:alpine
 RUN set -eux \
     # Install build tools. These can be required for the `pip-compile` step in
     # child images that require to build packages from source.
-    && apk add g++ \
+    && apk add build-base \
     # Re-run pip-compile in order to pre-populate the pip cache.
     && pip-compile --generate-hashes --output-file /dev/null \
       /opt/base-requirements.txt

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,6 @@ RUN set -eux \
     # Pre-install the compiled requirements to save some build time for child
     # images.
     && pip-sync base-requirements.txt \
-    # Remove build dependencies and pip cache to reduce layer size. Note that
-    # the pip-tools cache is kept to speed up `pip-compile` in child images.
+    # Remove build dependencies and pip cache to reduce layer size.
     && apk del .build-deps \
-    && rm -rf /root/.cache/pip
+    && rm -rf /root/.cache

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -28,7 +28,7 @@ COPY base-requirements.in ./
 RUN set -eux \
     # Install build dependencies to make sure we can build packages that don't
     # provide pre-built wheels from source.
-    && apk add --no-cache --virtual .build-deps g++ \
+    && apk add --no-cache --virtual .build-deps build-base \
     # Make sure to use the latest python build tools.
     && pip install --upgrade pip setuptools wheel pip-tools \
     # Fetch the latest versions of all requirements. It is OK if this fails the

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -40,6 +40,5 @@ RUN set -eux \
     # Pre-install the compiled requirements to save some build time for child
     # images.
     && pip-sync base-requirements.txt \
-    # Remove the pip cache to reduce layer size. Note that the pip-tools cache
-    # is kept to speed up `pip-compile` in child images.
-    && rm -rf /root/.cache/pip
+    # Remove the pip cache to reduce layer size.
+    && rm -rf /root/.cache


### PR DESCRIPTION
The compiler image contains build tools and the pip cache, and can be
used to perform `pip-compile` in child services.