### PR TITLE
chore: remove pydocstyle compatibility constraint

### DIFF
--- a/alpine/base-requirements.in
+++ b/alpine/base-requirements.in
@@ -24,10 +24,6 @@ ipython
 
 # Compatibility constraints
 
-# pydocstyle (dependency of flake8-docstrings): pin to v3.0.0 until
-# flake8-docstrings fixes compatibility with v4.0.0
-pydocstyle==3.0.0
-
 # apispec and marshmallow (dependencies of flask-apispec): Upgrading to latest
 # version yields the following error:
 # TypeError: ... got an unexpected keyword argument 'partial'


### PR DESCRIPTION
The issue seems to have been resolved.