### PR TITLE
Run test suite based on the built image base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,13 @@ env:
   - IMAGE_HASH_TAG=${TRAVIS_COMMIT::12}
 before_install:
 - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin
+- pip install --user cookiecutter
 install:
 - docker build -t ${IMAGE}:alpine -t ${IMAGE}:alpine-${IMAGE_HASH_TAG} ./alpine
 - docker build -t ${IMAGE}:alpine-compiler -t ${IMAGE}:alpine-compiler-${IMAGE_HASH_TAG} ./alpine-compiler
 - docker build -t ${IMAGE}:debian -t ${IMAGE}:debian-${IMAGE_HASH_TAG} ./debian
 script:
-- docker run --rm ${IMAGE}:alpine gunicorn --version
+- ./.travis/test-alpine.sh
 - docker run --rm ${IMAGE}:debian gunicorn --version
 after_success:
 - docker push ${IMAGE}:alpine

--- a/.travis/test-alpine.sh
+++ b/.travis/test-alpine.sh
@@ -1,0 +1,8 @@
+set -eux
+cookiecutter --no-input https://github.com/DD-DeCaF/cookiecutter-flask-microservice
+pushd name-of-the-project
+make pip-compile
+# The generated requirements file is initially owned by root, so update ownership.
+sudo chown -R travis .
+make network build qa
+popd

--- a/.travis/test-alpine.sh
+++ b/.travis/test-alpine.sh
@@ -4,5 +4,5 @@ pushd name-of-the-project
 make pip-compile
 # The generated requirements file is initially owned by root, so update ownership.
 sudo chown -R travis .
-make network build qa
+make setup build qa
 popd


### PR DESCRIPTION
This ensures that the compiled requirements do not break anything that's tested for in the QA suite.

Note that [the cookiecutter PR](https://github.com/DD-DeCaF/cookiecutter-flask-microservice/pull/99) is similar, but only tests the code in the cookiecutter itself. This, in comparison, tests if the (potentially) upgraded base image dependencies break anything.