### PR TITLE
chore: remove flask-apispec compatibility constraints

### DIFF
--- a/alpine/base-requirements.in
+++ b/alpine/base-requirements.in
@@ -21,11 +21,3 @@ flake8-bugbear
 isort
 safety
 ipython
-
-# Compatibility constraints
-
-# apispec and marshmallow (dependencies of flask-apispec): Upgrading to latest
-# version yields the following error:
-# TypeError: ... got an unexpected keyword argument 'partial'
-apispec==2.0.2
-marshmallow==2.19.5

--- a/debian/base-requirements.in
+++ b/debian/base-requirements.in
@@ -21,15 +21,3 @@ flake8-bugbear
 isort
 safety
 ipython
-
-# Compatibility constraints
-
-# pydocstyle (dependency of flake8-docstrings): pin to v3.0.0 until
-# flake8-docstrings fixes compatibility with v4.0.0
-pydocstyle==3.0.0
-
-# apispec and marshmallow (dependencies of flask-apispec): Upgrading to latest
-# version yields the following error:
-# TypeError: ... got an unexpected keyword argument 'partial'
-apispec==2.0.2
-marshmallow==2.19.5


### PR DESCRIPTION
The newer versions simply require that custom Field implementations in
our services are updated.