### PR TITLE
Constrain gunicorn

### DIFF
--- a/.travis/test-alpine.sh
+++ b/.travis/test-alpine.sh
@@ -1,4 +1,12 @@
 set -eux
+
+# Test the image (alpine packages + python dependencies) by creating a service
+# on top of the base image that was just built, and run the QA suite.
+# Note that we're using the master branch of the cookiecutter repo, which has
+# already passed QA. Hence, we're not testing the state of the cookiecutter
+# here - just that it works with the new dependencies installed in the base
+# image.
+
 cookiecutter --no-input https://github.com/DD-DeCaF/cookiecutter-flask-microservice
 pushd name-of-the-project
 make pip-compile

--- a/alpine/base-requirements.in
+++ b/alpine/base-requirements.in
@@ -21,3 +21,9 @@ flake8-bugbear
 isort
 safety
 ipython
+
+# Gunicorn 20 requires libc. It could be added through the alpine `libc-dev`
+# package, but for some reason it's not recognized by Python.
+# Consider using a pure alpine image and adding the distribution's packaged
+# Python instead. See https://stackoverflow.com/a/58795175/302484
+gunicorn==19.9.0


### PR DESCRIPTION
Gunicorn 20 requires libc. A quick test of simply adding `libc-dev` in the alpine image didn't work, so let's just downgrade for now.