### PR TITLE
Chore upgrade base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DEBIAN_TAG := debian_${BUILD_DATE}_${SHORT_COMMIT}
 
 ## Build the Alpine Linux base image.
 build-alpine:
-	docker pull python:3.6-alpine3.10
+	docker pull python:3.6-alpine3.13
 	docker build \
 		--build-arg BUILD_COMMIT=$(BUILD_COMMIT) \
 		--tag $(IMAGE):alpine \

--- a/alpine-compiler/Dockerfile
+++ b/alpine-compiler/Dockerfile
@@ -26,7 +26,7 @@ LABEL dk.dtu.biosustain.wsgi-base.alpine-compiler.build.commit="${BUILD_COMMIT}"
 RUN set -eux \
     # Install build tools. These can be required for the `pip-compile` step in
     # child images that require to build packages from source.
-    && apk add --no-cache build-base libffi-dev \
+    && apk add --no-cache build-base libffi-dev git \
     # Re-run pip-compile in order to pre-populate the pip cache.
     && pip-compile --allow-unsafe --generate-hashes --verbose \
         --output-file /dev/null /opt/base-requirements.txt \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6-alpine3.10
+FROM python:3.6-alpine3.13
 
 ARG BUILD_COMMIT
 


### PR DESCRIPTION
### Description

Latest version of py2neo in id-mapper (see https://github.com/DD-DeCaF/id-mapper/issues/19) requires an update of the alpine base image:

> py2neo(2021.1.5) <- [cryptography](https://cryptography.io/en/latest/installation/) <- rust(>=1.41) <- rustup <- alpine(3.13)

where `<-` is "depends on".

### Changes

* Update alpine base image to `alpine3.6-alpine:3.13`.
* Installed git.
